### PR TITLE
feat: log style cache usage

### DIFF
--- a/figregistry-kedro/src/figregistry_kedro/datasets.py
+++ b/figregistry-kedro/src/figregistry_kedro/datasets.py
@@ -563,8 +563,14 @@ class FigureDataSet(AbstractDataset[Figure, Figure]):
             with _cache_lock:
                 if cache_key in _style_cache:
                     _performance_metrics["cache_hits"] += 1
+                    logger.debug(
+                        "Style configuration cache hit for key %s", cache_key
+                    )
                     return copy.deepcopy(_style_cache[cache_key])
                 _performance_metrics["cache_misses"] += 1
+                logger.debug(
+                    "Style configuration cache miss for key %s", cache_key
+                )
         
         try:
             # Get base style from FigRegistry
@@ -580,6 +586,10 @@ class FigureDataSet(AbstractDataset[Figure, Figure]):
             if self._cache_enabled:
                 with _cache_lock:
                     _style_cache[cache_key] = copy.deepcopy(merged_style)
+                    logger.debug(
+                        "Cached computed style configuration for key %s",
+                        cache_key,
+                    )
             
             return merged_style
             

--- a/figregistry-kedro/tests/test_datasets.py
+++ b/figregistry-kedro/tests/test_datasets.py
@@ -1144,6 +1144,24 @@ class TestPerformanceRequirements:
         
         # Verify FigRegistry called only once (cache working)
         assert mock_figregistry_api['get_style'].call_count == 1
+
+    def test_style_cache_logging(self, basic_dataset_config, mock_figregistry_api, caplog):
+        """Test debug logging for cache hits and misses."""
+
+        dataset = FigureDataSet(**basic_dataset_config)
+        condition = 'cache_test'
+
+        with caplog.at_level('DEBUG'):
+            dataset._get_style_configuration(condition)
+
+        assert any('cache miss' in record.message.lower() for record in caplog.records)
+
+        caplog.clear()
+
+        with caplog.at_level('DEBUG'):
+            dataset._get_style_configuration(condition)
+
+        assert any('cache hit' in record.message.lower() for record in caplog.records)
     
     @pytest.mark.performance
     @pytest.mark.skipif(not BENCHMARK_AVAILABLE, reason="pytest-benchmark not available")


### PR DESCRIPTION
## Summary
- log when style config is loaded from cache
- log when style config is cached after computation
- test new logging of cache hits and misses

## Testing
- `pytest -q -o addopts='' figregistry-kedro/tests` *(fails: ModuleNotFoundError: No module named 'figregistry_kedro')*

------
https://chatgpt.com/codex/tasks/task_e_684a2f8227cc8320805afd0ec87ef7e1