### PR TITLE
Add plugin comparison in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ Configuration translation layer between Kedro and FigRegistry:
 - Unified configuration source eliminating duplicate configuration management
 - Automatic validation and type safety across both systems
 
+### Comparison with Kedro's `MatplotlibWriter`
+
+`figregistry-kedro` extends Kedro's built-in `MatplotlibWriter` with several additional capabilities:
+
+- **Automated Styling & Saving**: Figures are styled and saved automatically based on your FigRegistry configuration, eliminating most `plt.savefig()` boilerplate.
+- **Configuration Merging**: Plugin settings merge with your `figregistry.yaml`, so you can keep existing FigRegistry settings alongside Kedro configuration.
+- **Condition-Based Styling**: Styles change dynamically according to pipeline parameters, reducing manual code for different output conditions.
+
 ### Kedro Plugin Quick Start
 
 1. Install the plugin:


### PR DESCRIPTION
## Summary
- explain how `figregistry-kedro` differs from Kedro's `MatplotlibWriter`

## Testing
- `pytest` *(fails: unrecognized arguments)*
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a34433c908320914408cba5cc50bc